### PR TITLE
Fixed hardware uart enabler

### DIFF
--- a/Firmware/MiraFW/src/mira/boot/patches/patches505.c
+++ b/Firmware/MiraFW/src/mira/boot/patches/patches505.c
@@ -16,7 +16,7 @@ void install_prerunPatches_505()
 	cpu_disable_wp();
 	
 	// enable UART
-  	gKernelBase[0x09ECEB0] = 0;
+  	gKernelBase[0x19ECEB0] = 0;
 
 	// Verbose Panics
 	uint8_t *kmem = (uint8_t *)&gKernelBase[0x00171580];


### PR DESCRIPTION
Fixed the kernel offset for enabling uart via physically connected wires. I tested it for 5.05 and it's working.