### PR TITLE
overlayFS

### DIFF
--- a/Firmware/MiraFW/src/mira/fs/overlay/overlayfs.c
+++ b/Firmware/MiraFW/src/mira/fs/overlay/overlayfs.c
@@ -258,7 +258,7 @@ int overlayfs_rmdirHook(struct thread* td, struct rmdir_args* uap)
 			snprintf(app_folder, 300, "/mnt/sandbox/%s_000", appid);
 
 			int ret = -1;
-			if (strstr(app_folder, path) == 0) {
+			if (strcmp(app_folder, path) == 0) {
 				struct thread_info_t prevInfo;
 				memset(&prevInfo, 0, sizeof(prevInfo));
 

--- a/Firmware/MiraFW/src/mira/fs/overlay/overlayfs.c
+++ b/Firmware/MiraFW/src/mira/fs/overlay/overlayfs.c
@@ -396,7 +396,7 @@ int overlayfs_onExecNewVmspace(struct image_params* imgp, struct sysentvec* sv)
 	if (result < 0)
 	{
 		WriteLog(LL_Warn, "could not mount NullFS %s on %s ! (%d)", pfsmnt_app, app0, result);
-		goto end_root;
+		//goto end_root;
 	}
 
 	// Mount mod0 in pfsmnt (from /user/data)

--- a/Firmware/MiraFW/src/mira/fs/overlay/overlayfs.c
+++ b/Firmware/MiraFW/src/mira/fs/overlay/overlayfs.c
@@ -231,9 +231,7 @@ int overlayfs_rmdirHook(struct thread* td, struct rmdir_args* uap)
 	size_t path_len;
 	copyinstr(uap->path, path, sizeof(path), &path_len);
 
-	if (strcmp("SceShellCore", p->p_comm) != 0)
-		return 0;
-
+	if (strcmp("SceShellCore", p->p_comm) == 0)
 	{
 		char* pos1 = strstr(path, "/mnt/sandbox/");
 		char* pos2 = strstr(path, "/mnt/sandbox/pfsmnt/");
@@ -260,7 +258,6 @@ int overlayfs_rmdirHook(struct thread* td, struct rmdir_args* uap)
 			snprintf(app_folder, 300, "/mnt/sandbox/%s_000", appid);
 
 			int ret = -1;
-
 			if (strstr(app_folder, path) == 0) {
 				struct thread_info_t prevInfo;
 				memset(&prevInfo, 0, sizeof(prevInfo));


### PR DESCRIPTION
Just want to comment on ece9ce9, I spoke to @theorywrong and he also commented about removing that unmount block all together, and I'm more than happy to recommit that code to do so, if that was the final consensus.

finally, [overlayfs.c Line 260](https://github.com/OpenOrbis/mira-project/blob/feature/refactor1_2/Firmware/MiraFW/src/mira/fs/overlay/overlayfs.c#L260), for most of my test I unmount the mod directory when `./dev` is deleted, as it's a good indiction the game is getting unmounted, however, I also want to test how the code behaves if left unchanged (but due to time shortage I haven't yet, it seemed to have fixed my initial kpanics, and due to lack of time  I stuck with it none the less, however, I avoided committing the code for a potentially unnecessary change, but its something to keep an eye on (I will however test it once I get the chance to do so))